### PR TITLE
fix: 变量定义语法错误

### DIFF
--- a/docs/typings/generices.md
+++ b/docs/typings/generices.md
@@ -83,7 +83,7 @@ function reverse<T>(items: T[]): T[] {
 }
 
 const sample = [1, 2, 3];
-const reversed = reverse(sample);
+let reversed = reverse(sample);
 
 reversed[0] = '1'; // Error
 reversed = ['1', '2']; // Error


### PR DESCRIPTION
const 定义 reversed 后在下文又被赋值，改为 let 或 var