### PR TITLE
doc(module):调整模块推荐写法文案，避免歧义

### DIFF
--- a/docs/project/modules.md
+++ b/docs/project/modules.md
@@ -57,7 +57,8 @@ const bar = foo; // allow
 
 怎么书写 TypeScript 模块，这也是一件让人困惑的事。在今天我们应该这么做：
 
-- 使用 ES 模块语法代替 `import foo = require('foo')` 即 `import/require` 语法，
+- 放弃使用`import/require`语法即`import foo = require('foo')`写法
+- 推荐使用 ES 模块语法
 
 这很酷，接下来，让我们看看 ES 模块语法。
 


### PR DESCRIPTION
首先感谢作者的辛勤付出👏；

其次我在阅读时，发现下面问题:

- Typescript项目 - 模块章节下

- 关于推荐的模块写法存在歧义;

```
怎么书写 TypeScript 模块，这也是一件让人困惑的事。在今天我们应该这么做：

使用 ES 模块语法代替 import foo = require('foo') 即 import/require 语法，
```

- 新手可能无法区分`ES 模块语法`、 `import foo = require('foo')`、`import/require 语法`这3个概念的意思
- 其可能理解为 `ES 模块语法`和`import/require 语法`是同一个概念，也可能理解为`import foo = require('foo')`、`import/require 语法`是同一个概念；存在一定的语法歧义；(我让同事阅读了一下，他也认为存在一定歧义😢)

- 修改成下面的形式，是否更清晰😃:

```
怎么书写 TypeScript 模块，这也是一件让人困惑的事。在今天我们应该这么做：

放弃使用`import/require`语法即`import foo = require('foo')`写法

推荐使用 ES 模块语法
```