### PR TITLE
函数声明 -> 函数重载

### DIFF
--- a/docs/typings/functions.md
+++ b/docs/typings/functions.md
@@ -158,7 +158,7 @@ type LongHand = {
 type ShortHand = (a: number) => number;
 ```
 
-上面代码中的两个例子完全相同。但是，当你想使用函数重载时，只能用第一种方式:
+上面代码中的两个例子完全相同。但是，当你想使用函数重载时，只能用下边这种方式:
 
 ```ts
 type LongHandAllowsOverloadDeclarations = {


### PR DESCRIPTION
只能用第一种方式 -> 只能用下边这种方式
函数重载应该是用 LongHandAllowsOverloadDeclarations 这个类型定义, 原文的说法容易让人觉得是上边的类型定义