### PR TITLE
拼写错误

### DIFF
--- a/docs/tips/avoidExportDefault.md
+++ b/docs/tips/avoidExportDefault.md
@@ -71,5 +71,5 @@ import /* here */ 'something';
 
 ```ts
 const HighChart = await import('https://code.highcharts.com/js/es-modules/masters/highcharts.src.js');
-Highcharts.default.chart('container', { ... }); // Notice `.default`
+HighChart.default.chart('container', { ... }); // Notice `.default`
 ```


### PR DESCRIPTION
顺手修改了简单的拼写错误。
同时有个小小的疑问：import('https://code.highcharts.com/js/es-modules/masters/highcharts.src.js')；中
TS提示：找不到模块“https://code.highcharts.com/js/es-modules/masters/highcharts.src.js”。ts(2307)
请问是import本身设计的问题吗？