### PR TITLE
修复示例代码错误

### DIFF
--- a/docs/typings/overview.md
+++ b/docs/typings/overview.md
@@ -245,7 +245,7 @@ function formatCommandline(command: string[] | string) {
 在 JavaScript 中， `extend` 是一种非常常见的模式，在这种模式中，你可以从两个对象中创建一个新对象，新对象会拥有着两个对象所有的功能。交叉类型可以让你安全的使用此种模式：
 
 ```ts
-function extend<T, U>(first: T, second: U): T & U {
+function extend<T extends object, U extends object>(first: T, second: U): T & U {
   const result = <T & U>{};
   for (let id in first) {
     (<T>result)[id] = first[id];


### PR DESCRIPTION
译文地址：https://jkchao.github.io/typescript-book-chinese/typings/overview.html#%E7%B1%BB%E5%9E%8B%E5%88%AB%E5%90%8D

联合类型示例中的泛型 T 和 U 默认类型是 unknown，他们的结果 result 类型时 T & U 也是 unknown 类型，调用 result.hasOwnProperty() 方法是非法的。
```typescript
function extend<T, U>(first: T, second: U): T & U {
  const result = <T & U>{};
  for (let id in first) {
    (<T>result)[id] = first[id];
  }
  for (let id in second) {
    if (!result.hasOwnProperty(id)) {
      (<U>result)[id] = second[id];
    }
  }

  return result;
}
```

正确示例应当使 T 和 U 均继承自 object 类型