### PR TITLE
更新 gh-pages.yml 缩短部署时间

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,19 +19,11 @@ jobs:
       with:
         ref: master
 
-    - name: Setup Node
-      uses: actions/setup-node@v1
-      with:
-        node-version: '10.x'
-
-    - name: Install yarn
-      run: npm install yarn -g
-
     - name: Install Dependencies
       run: yarn
 
     - name: Build
-      run: npm run build
+      run: yarn build
 
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v2


### PR DESCRIPTION
在我repo里测过，除了 Deploy 因为没有ACTIONS_DEPLOY_KEY，无法运行通过，其它都没问题，详见：https://github.com/Kennytian/typescript-book-chinese/runs/604455574?check_suite_focus=true