### PR TITLE
update: 修改两处FAQ的外链到官方有解释的地方

### DIFF
--- a/docs/faqs/class.md
+++ b/docs/faqs/class.md
@@ -140,7 +140,7 @@ class Foo {
 interface Bar extends Foo {}
 ```
 
-这创建了一个名叫 `Bar` 的类型，它与 `Foo` 的实例具有相同的成员。当 `Foo` 具有私有成员时，`Bar` 内的相同属性，必须由一个继承自 `Foo` 的类实现。总的来说，这种模式是应当避免的，尤其是在 `Foo` 由私有成员时。
+这创建了一个名叫 `Bar` 的类型，它与 `Foo` 的实例具有相同的成员。当 `Foo` 具有私有成员时，`Bar` 内的相同属性，必须由一个继承自 `Foo` 的类实现。总的来说，这种模式是应当避免的，尤其是在 `Foo` 有私有成员时。
 
 ## 为什么我会得到错误：`TypeError: [base class name] is not defined in __extends`？
 

--- a/docs/faqs/enums.md
+++ b/docs/faqs/enums.md
@@ -2,4 +2,4 @@
 
 ## `enum` 和 `const enum` 之间的区别是什么？
 
-TODO：`enum` / `const enum` 有如下区别，请看：[http://stackoverflow.com/questions/28818849/how-do-the-different-enum-variants-work-in-typescript](http://stackoverflow.com/questions/28818849/how-do-the-different-enum-variants-work-in-typescript)
+TODO：`enum` / `const enum` 有如下区别，请看：[https://www.typescriptlang.org/docs/handbook/enums.html#enums](https://www.typescriptlang.org/docs/handbook/enums.html#enums)

--- a/docs/faqs/modules.md
+++ b/docs/faqs/modules.md
@@ -35,4 +35,4 @@ someModule; // Used for side effects
 
 ## 为什么不跨模块文件合并命名空间？
 
-TODO：本小节内容请查看：[https://stackoverflow.com/questions/30357634/how-do-i-use-namespaces-with-typescript-external-modules](https://stackoverflow.com/questions/30357634/how-do-i-use-namespaces-with-typescript-external-modules)
+TODO：本小节内容请查看：[https://stackoverflow.com/questions/30357634/how-do-i-use-namespaces-with-typescript-external-modules](https://stackoverflow.com/questions/30357634/how-do-i-use-namespaces-with-typescript-external-modules) 或者 [https://www.typescriptlang.org/docs/handbook/release-notes/typescript-1-5.html#namespace-keyword](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-1-5.html#namespace-keyword)


### PR DESCRIPTION
两处的TODO都有官方解释了，我们不应该再Redirect到StackoverFlow上