### PR TITLE
Add Omitted Paremeter and Remove Redundant Semicolon

### DIFF
--- a/docs/typings/exceptionsHanding.md
+++ b/docs/typings/exceptionsHanding.md
@@ -137,7 +137,7 @@ try {
 }
 
 try {
-  const bar = runTask2();
+  const bar = runTask2(foo);
 } catch (e) {
   console.log('Error:', e);
 }
@@ -159,7 +159,7 @@ function validate(value: number) {
 
 ```ts
 function validate(
-  value: number;
+  value: number
 ): {
   error?: string;
 } {


### PR DESCRIPTION
纠正异常处理中的两个小问题：
1. 优雅捕获错误的第二个示例，是为了演示将第 1 个任务的内容传递给第 2 个任务，所以应该把 `foo` 作为第 2 个任务的参数
2. 创建验证方法的示例，在参数注解中多了一个分号，会导致错误 `error TS1005: ',' expected.`，所以应该去除
