### PR TITLE
更新ParamType泛型

### DIFF
--- a/docs/tips/infer.md
+++ b/docs/tips/infer.md
@@ -7,12 +7,12 @@
 简单示例如下：
 
 ```ts
-type ParamType<T> = T extends (param: infer P) => any ? P : T;
+type ParamType<T> = T extends (...args: infer P) => any ? P : T;
 ```
 
-在这个条件语句 `T extends (param: infer P) => any ? P : T` 中，`infer P` 表示待推断的函数参数。
+在这个条件语句 `T extends (...args: infer P) => any ? P : T` 中，`infer P` 表示待推断的函数参数。
 
-整句表示为：如果 `T` 能赋值给 `(param: infer P) => any`，则结果是 `(param: infer P) => any` 类型中的参数 `P`，否则返回为 `T`。
+整句表示为：如果 `T` 能赋值给 `(...args: infer P) => any`，则结果是 `(...args: infer P) => any` 类型中的参数 `P`，否则返回为 `T`。
 
 ```ts
 interface User {


### PR DESCRIPTION
函数参数列表应该是一个类数组，如果写成
```js
 type Parameter<T> = T extends (param: infer R) => any ? R : never
```
会导致只能推断出单参数的返回类型，实际上函数可能会有多个参数，因为应改为
```js
 type Parameter<T> = T extends (..args: infer R) => any ? R : never
```