### PR TITLE
docs: 修正错误

### DIFF
--- a/docs/tips/infer.md
+++ b/docs/tips/infer.md
@@ -7,12 +7,12 @@
 简单示例如下：
 
 ```ts
-type ParamType<T> = T extends (...args: infer P) => any ? P : T;
+type ParamType<T> = T extends (arg: infer P) => any ? P : T;
 ```
 
-在这个条件语句 `T extends (...args: infer P) => any ? P : T` 中，`infer P` 表示待推断的函数参数。
+在这个条件语句 `T extends (arg: infer P) => any ? P : T` 中，`infer P` 表示待推断的函数参数。
 
-整句表示为：如果 `T` 能赋值给 `(...args: infer P) => any`，则结果是 `(...args: infer P) => any` 类型中的参数 `P`，否则返回为 `T`。
+整句表示为：如果 `T` 能赋值给 `(arg: infer P) => any`，则结果是 `(arg: infer P) => any` 类型中的参数 `P`，否则返回为 `T`。
 
 ```ts
 interface User {


### PR DESCRIPTION
如果不修改,则 `type Param` 代码的运行结果不正确,因为 `infer P` 指代的是参数数组 [User]:
```ts
type ParamType<T> = T extends (...args: infer P) => any ? P : T;
type Func = (user: User) => void;

type Param = ParamType<Func>; // type Param = [user: User] 而不是 type Param = User
```