### PR TITLE
change ParamType return value

### DIFF
--- a/docs/tips/infer.md
+++ b/docs/tips/infer.md
@@ -22,7 +22,7 @@ interface User {
 
 type Func = (user: User) => void;
 
-type Param = ParamType<Func>; // Param = User
+type Param = ParamType<Func>; // Param = [user: User]
 type AA = ParamType<string>; // string
 ```
 


### PR DESCRIPTION
``` ts
interface User {
  name: string;
  age: number;
}

type Func = (user: User) => void;

type Param = ParamType<Func>;
```

`Param`返回的应该是一个`[user: User]`