### PR TITLE
fix: 修复示例错误

### DIFF
--- a/docs/typings/indexSignatures.md
+++ b/docs/typings/indexSignatures.md
@@ -132,7 +132,7 @@ foo['a'].messages;
 ```
 
 ::: tip
-索引签名的名称（如：`{ [index: string]: { message: string } }` 里的 `index` ）除了可读性外，并没有任何意义。例如：如果有一个用户名，你可以使用 `{ username: string}: { message: string }`，这有利于下一个开发者理解你的代码。
+索引签名的名称（如：`{ [index: string]: { message: string } }` 里的 `index` ）除了可读性外，并没有任何意义。例如：如果有一个用户名，你可以使用 `{ [username: string]: { message: string } }`，这有利于下一个开发者理解你的代码。
 :::
 
 `number` 类型的索引也支持：`{ [count: number]: 'SomeOtherTypeYouWantToStoreEgRebate' }`。


### PR DESCRIPTION
原文：
> if it's user names you can do **`{ [username:string] : {message: string} }`** to help the next dev who looks at the code (which just might happen to be you)

本文：
> 如果有一个用户名，你可以使用 **`{ username: string}: { message: string }`**，这有利于下一个开发者理解你的代码。
